### PR TITLE
feat: add ConvoAI debug controls and align iOS CI artifacts

### DIFF
--- a/Android/common/src/main/java/io/agora/scene/common/debugMode/DebugConfigSettings.kt
+++ b/Android/common/src/main/java/io/agora/scene/common/debugMode/DebugConfigSettings.kt
@@ -49,6 +49,20 @@ object DebugConfigSettings {
         this.convoAIParameter = apiParameter
     }
 
+    var convoAiRequestBaseUrl: String = ""
+        private set
+
+    fun setConvoAiRequestBaseUrl(baseUrl: String) {
+        this.convoAiRequestBaseUrl = baseUrl
+    }
+
+    var convoAiRequestHeaderNamespace: String = ""
+        private set
+
+    fun setConvoAiRequestHeaderNamespace(namespace: String) {
+        this.convoAiRequestHeaderNamespace = namespace
+    }
+
     @Volatile
     private var _isDebug: Boolean = false
     
@@ -143,6 +157,8 @@ object DebugConfigSettings {
         isMetricsEnabled = false
         _sdkAudioParameters.clear()
         convoAIParameter = ""
+        convoAiRequestBaseUrl = ""
+        convoAiRequestHeaderNamespace = ""
     }
 
     // Counter for debug mode activation

--- a/Android/common/src/main/java/io/agora/scene/common/debugMode/DebugConfigSettings.kt
+++ b/Android/common/src/main/java/io/agora/scene/common/debugMode/DebugConfigSettings.kt
@@ -116,6 +116,20 @@ object DebugConfigSettings {
         this.isSessionLimitMode = isSessionLimitMode
     }
 
+    var audioScenario: Int? = null
+        private set
+
+    fun setAudioScenario(scenario: Int?) {
+        this.audioScenario = scenario
+    }
+
+    var serverAudioScenario: String? = null
+        private set
+
+    fun setServerAudioScenario(scenario: String?) {
+        this.serverAudioScenario = scenario
+    }
+
     var isMetricsEnabled: Boolean = false
         private set
 
@@ -155,6 +169,8 @@ object DebugConfigSettings {
         isDebug = false
         isAudioDumpEnabled = false
         isMetricsEnabled = false
+        audioScenario = null
+        serverAudioScenario = null
         _sdkAudioParameters.clear()
         convoAIParameter = ""
         convoAiRequestBaseUrl = ""

--- a/Android/common/src/main/java/io/agora/scene/common/debugMode/DebugCovConfigFragment.kt
+++ b/Android/common/src/main/java/io/agora/scene/common/debugMode/DebugCovConfigFragment.kt
@@ -125,8 +125,34 @@ class DebugCovConfigFragment : BaseFragment<CommonDebugCovConfigFragmentBinding>
                 }
             }
 
+            etConvoaiRequestBaseUrl.setText(DebugConfigSettings.convoAiRequestBaseUrl)
+            etConvoaiRequestBaseUrl.setOnFocusChangeListener { _, hasFocus ->
+                if (!hasFocus) {
+                    DebugConfigSettings.setConvoAiRequestBaseUrl(
+                        etConvoaiRequestBaseUrl.text.toString().trim()
+                    )
+                }
+            }
+
+            etConvoaiRequestHeader.setText(DebugConfigSettings.convoAiRequestHeaderNamespace)
+            etConvoaiRequestHeader.setOnFocusChangeListener { _, hasFocus ->
+                if (!hasFocus) {
+                    DebugConfigSettings.setConvoAiRequestHeaderNamespace(
+                        etConvoaiRequestHeader.text.toString().trim()
+                    )
+                }
+            }
+
             view.setOnTouchListener { _, _ ->
                 when {
+                    etConvoaiRequestBaseUrl.hasFocus() -> {
+                        etConvoaiRequestBaseUrl.clearFocus()
+                        hideKeyboard()
+                    }
+                    etConvoaiRequestHeader.hasFocus() -> {
+                        etConvoaiRequestHeader.clearFocus()
+                        hideKeyboard()
+                    }
                     etGraphId.hasFocus() -> {
                         etGraphId.clearFocus()
                         hideKeyboard()
@@ -167,6 +193,8 @@ class DebugCovConfigFragment : BaseFragment<CommonDebugCovConfigFragmentBinding>
                     // Keyboard is hidden - clear focus from input fields
                     mBinding?.apply {
                         when {
+                            etConvoaiRequestBaseUrl.hasFocus() -> etConvoaiRequestBaseUrl.clearFocus()
+                            etConvoaiRequestHeader.hasFocus() -> etConvoaiRequestHeader.clearFocus()
                             etGraphId.hasFocus() -> etGraphId.clearFocus()
                             etSdkAudioParameter.hasFocus() -> etSdkAudioParameter.clearFocus()
                             etApiParameter.hasFocus() -> etApiParameter.clearFocus()

--- a/Android/common/src/main/java/io/agora/scene/common/debugMode/DebugCovConfigFragment.kt
+++ b/Android/common/src/main/java/io/agora/scene/common/debugMode/DebugCovConfigFragment.kt
@@ -1,13 +1,22 @@
 package io.agora.scene.common.debugMode
 
+import android.app.Dialog
 import android.content.Context
+import android.graphics.Color
 import android.graphics.Paint
 import android.graphics.Rect
+import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.view.Window
 import android.view.inputmethod.InputMethodManager
+import androidx.recyclerview.widget.LinearLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import io.agora.scene.common.R
+import io.agora.scene.common.databinding.CommonDebugAudioScenarioDialogBinding
+import io.agora.scene.common.databinding.CommonDebugAudioScenarioOptionItemBinding
 import io.agora.scene.common.databinding.CommonDebugCovConfigFragmentBinding
 import io.agora.scene.common.debugMode.DebugTabDialog.DebugCallback
 import io.agora.scene.common.ui.BaseFragment
@@ -24,6 +33,16 @@ import kotlin.text.trim
 import kotlin.toString
 
 class DebugCovConfigFragment : BaseFragment<CommonDebugCovConfigFragmentBinding>() {
+
+    private data class AudioScenarioOption(
+        val label: String,
+        val scenario: Int?
+    )
+
+    private data class ServerAudioScenarioOption(
+        val label: String,
+        val scenario: String?
+    )
 
     companion object {
         private const val TAG = "DebugCovConfigFragment"
@@ -116,6 +135,30 @@ class DebugCovConfigFragment : BaseFragment<CommonDebugCovConfigFragmentBinding>
                 }
             }
 
+            updateAudioScenarioValue()
+            layoutAudioScenario.setOnClickListener {
+                showAudioScenarioDialog(
+                    title = getString(R.string.common_debug_audio_scenario),
+                    options = clientAudioScenarioOptions(),
+                    selectedScenario = DebugConfigSettings.audioScenario
+                ) {
+                    DebugConfigSettings.setAudioScenario(it)
+                    updateAudioScenarioValue()
+                }
+            }
+
+            updateServerAudioScenarioValue()
+            layoutServerAudioScenario.setOnClickListener {
+                showServerAudioScenarioDialog(
+                    title = getString(R.string.common_debug_server_audio_scenario),
+                    options = serverAudioScenarioOptions(),
+                    selectedScenario = DebugConfigSettings.serverAudioScenario
+                ) {
+                    DebugConfigSettings.setServerAudioScenario(it)
+                    updateServerAudioScenarioValue()
+                }
+            }
+
             etApiParameter.setHint("sess_ctrl_dev")
             etApiParameter.setText(DebugConfigSettings.convoAIParameter)
             etApiParameter.setOnFocusChangeListener { _, hasFocus ->
@@ -171,6 +214,190 @@ class DebugCovConfigFragment : BaseFragment<CommonDebugCovConfigFragmentBinding>
 
             // Setup keyboard visibility listener
             setupKeyboardVisibilityListener(view)
+        }
+    }
+
+    private fun commonAudioScenarioOptions(): List<AudioScenarioOption> {
+        return listOf(
+            AudioScenarioOption(getString(R.string.common_debug_audio_scenario_not_selected), null),
+            AudioScenarioOption("AUDIO_SCENARIO_DEFAULT (0)", 0),
+            AudioScenarioOption("AUDIO_SCENARIO_GAME_STREAMING (3)", 3),
+            AudioScenarioOption("AUDIO_SCENARIO_CHATROOM (5)", 5),
+            AudioScenarioOption("AUDIO_SCENARIO_CHORUS (7)", 7),
+            AudioScenarioOption("AUDIO_SCENARIO_MEETING (8)", 8)
+        )
+    }
+
+    private fun clientAudioScenarioOptions(): List<AudioScenarioOption> {
+        return commonAudioScenarioOptions() + AudioScenarioOption("AUDIO_SCENARIO_AI_CLIENT (10)", 10)
+    }
+
+    private fun serverAudioScenarioOptions(): List<ServerAudioScenarioOption> {
+        return listOf(
+            ServerAudioScenarioOption(getString(R.string.common_debug_audio_scenario_not_selected), null),
+            ServerAudioScenarioOption("default", "default"),
+            ServerAudioScenarioOption("chorus", "chorus"),
+            ServerAudioScenarioOption("aiserver", "aiserver")
+        )
+    }
+
+    private fun updateAudioScenarioValue() {
+        val selectedScenario = DebugConfigSettings.audioScenario
+        val selectedOption = clientAudioScenarioOptions().firstOrNull { it.scenario == selectedScenario }
+        mBinding?.tvAudioScenarioValue?.text =
+            selectedOption?.label ?: getString(R.string.common_debug_audio_scenario_not_selected)
+    }
+
+    private fun updateServerAudioScenarioValue() {
+        val selectedScenario = DebugConfigSettings.serverAudioScenario
+        val selectedOption = serverAudioScenarioOptions().firstOrNull { it.scenario == selectedScenario }
+        mBinding?.tvServerAudioScenarioValue?.text =
+            selectedOption?.label ?: getString(R.string.common_debug_audio_scenario_not_selected)
+    }
+
+    private fun showAudioScenarioDialog(
+        title: String,
+        options: List<AudioScenarioOption>,
+        selectedScenario: Int?,
+        onSelected: (Int?) -> Unit
+    ) {
+        val context = context ?: return
+        val selectedIndex = options.indexOfFirst { it.scenario == selectedScenario }
+            .takeIf { it >= 0 } ?: 0
+        val dialogBinding = CommonDebugAudioScenarioDialogBinding.inflate(LayoutInflater.from(context))
+        dialogBinding.tvTitle.text = title
+
+        val dialog = Dialog(context).apply {
+            requestWindowFeature(Window.FEATURE_NO_TITLE)
+            setContentView(dialogBinding.root)
+            window?.apply {
+                setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+                attributes = attributes.apply {
+                    windowAnimations = 0
+                    width = (resources.displayMetrics.widthPixels * 0.84f).toInt()
+                    height = ViewGroup.LayoutParams.WRAP_CONTENT
+                }
+            }
+        }
+
+        dialogBinding.rvOptions.layoutManager = LinearLayoutManager(context)
+        dialogBinding.rvOptions.adapter = AudioScenarioOptionsAdapter(options, selectedIndex) { which ->
+            onSelected(options[which].scenario)
+            dialog.dismiss()
+        }
+        dialogBinding.btnCancel.setOnClickListener {
+            dialog.dismiss()
+        }
+
+        dialog.show()
+    }
+
+    private fun showServerAudioScenarioDialog(
+        title: String,
+        options: List<ServerAudioScenarioOption>,
+        selectedScenario: String?,
+        onSelected: (String?) -> Unit
+    ) {
+        val context = context ?: return
+        val selectedIndex = options.indexOfFirst { it.scenario == selectedScenario }
+            .takeIf { it >= 0 } ?: 0
+        val dialogBinding = CommonDebugAudioScenarioDialogBinding.inflate(LayoutInflater.from(context))
+        dialogBinding.tvTitle.text = title
+
+        val dialog = Dialog(context).apply {
+            requestWindowFeature(Window.FEATURE_NO_TITLE)
+            setContentView(dialogBinding.root)
+            window?.apply {
+                setBackgroundDrawable(ColorDrawable(Color.TRANSPARENT))
+                attributes = attributes.apply {
+                    windowAnimations = 0
+                    width = (resources.displayMetrics.widthPixels * 0.84f).toInt()
+                    height = ViewGroup.LayoutParams.WRAP_CONTENT
+                }
+            }
+        }
+
+        dialogBinding.rvOptions.layoutManager = LinearLayoutManager(context)
+        dialogBinding.rvOptions.adapter = ServerAudioScenarioOptionsAdapter(options, selectedIndex) { which ->
+            onSelected(options[which].scenario)
+            dialog.dismiss()
+        }
+        dialogBinding.btnCancel.setOnClickListener {
+            dialog.dismiss()
+        }
+
+        dialog.show()
+    }
+
+    private class AudioScenarioOptionsAdapter(
+        private val options: List<AudioScenarioOption>,
+        private val selectedIndex: Int,
+        private val onSelect: (Int) -> Unit
+    ) : RecyclerView.Adapter<AudioScenarioOptionsAdapter.ViewHolder>() {
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+            return ViewHolder(
+                CommonDebugAudioScenarioOptionItemBinding.inflate(
+                    LayoutInflater.from(parent.context),
+                    parent,
+                    false
+                )
+            )
+        }
+
+        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+            holder.bind(options[position].label, position == selectedIndex)
+            holder.itemView.setOnClickListener {
+                onSelect(position)
+            }
+        }
+
+        override fun getItemCount(): Int = options.size
+
+        private class ViewHolder(
+            private val binding: CommonDebugAudioScenarioOptionItemBinding
+        ) : RecyclerView.ViewHolder(binding.root) {
+
+            fun bind(label: String, selected: Boolean) {
+                binding.tvText.text = label
+                binding.ivIcon.visibility = if (selected) View.VISIBLE else View.INVISIBLE
+            }
+        }
+    }
+
+    private class ServerAudioScenarioOptionsAdapter(
+        private val options: List<ServerAudioScenarioOption>,
+        private val selectedIndex: Int,
+        private val onSelect: (Int) -> Unit
+    ) : RecyclerView.Adapter<ServerAudioScenarioOptionsAdapter.ViewHolder>() {
+
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
+            return ViewHolder(
+                CommonDebugAudioScenarioOptionItemBinding.inflate(
+                    LayoutInflater.from(parent.context),
+                    parent,
+                    false
+                )
+            )
+        }
+
+        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
+            holder.bind(options[position].label, position == selectedIndex)
+            holder.itemView.setOnClickListener {
+                onSelect(position)
+            }
+        }
+
+        override fun getItemCount(): Int = options.size
+
+        private class ViewHolder(
+            private val binding: CommonDebugAudioScenarioOptionItemBinding
+        ) : RecyclerView.ViewHolder(binding.root) {
+
+            fun bind(label: String, selected: Boolean) {
+                binding.tvText.text = label
+                binding.ivIcon.visibility = if (selected) View.VISIBLE else View.INVISIBLE
+            }
         }
     }
 

--- a/Android/common/src/main/res/drawable/bg_common_dialog2.xml
+++ b/Android/common/src/main/res/drawable/bg_common_dialog2.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <shape xmlns:android="http://schemas.android.com/apk/res/android">
-    <solid android:color="@color/ai_block2" />
+    <solid android:color="@color/ai_block3" />
     <corners android:radius="16dp" />
 </shape>

--- a/Android/common/src/main/res/layout/common_debug_audio_scenario_dialog.xml
+++ b/Android/common/src/main/res/layout/common_debug_audio_scenario_dialog.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:background="@drawable/bg_common_dialog2"
+    android:orientation="vertical">
+
+    <TextView
+        android:id="@+id/tv_title"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:paddingHorizontal="24dp"
+        android:paddingTop="16dp"
+        android:paddingBottom="12dp"
+        android:text="@string/common_debug_audio_scenario"
+        android:textColor="@color/ai_icontext1"
+        android:textSize="16sp"
+        android:textStyle="bold" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/rv_options"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:maxHeight="320dp"
+        android:overScrollMode="ifContentScrolls"
+        android:paddingHorizontal="8dp"
+        tools:itemCount="7"
+        tools:listitem="@layout/common_debug_audio_scenario_option_item" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="0.5dp"
+        android:layout_marginTop="8dp"
+        android:background="@color/ai_line1" />
+
+    <com.google.android.material.button.MaterialButton
+        android:id="@+id/btn_cancel"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/ai_dp_small"
+        android:layout_marginHorizontal="24dp"
+        android:layout_marginTop="16dp"
+        android:layout_marginBottom="16dp"
+        android:insetTop="0dp"
+        android:insetBottom="0dp"
+        android:text="@string/common_cancel"
+        android:textAllCaps="false"
+        android:textColor="@color/ai_icontext2"
+        android:textSize="14sp"
+        app:backgroundTint="@color/ai_line2"
+        app:cornerRadius="12dp"
+        app:rippleColor="#1A000000" />
+
+</LinearLayout>

--- a/Android/common/src/main/res/layout/common_debug_audio_scenario_option_item.xml
+++ b/Android/common/src/main/res/layout/common_debug_audio_scenario_option_item.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="@dimen/ai_dp_small"
+    android:background="@android:color/transparent"
+    android:gravity="center_vertical"
+    android:orientation="horizontal"
+    android:paddingStart="16dp"
+    android:paddingEnd="12dp">
+
+    <TextView
+        android:id="@+id/tv_text"
+        android:layout_width="0dp"
+        android:layout_height="wrap_content"
+        android:layout_weight="1"
+        android:ellipsize="end"
+        android:maxLines="1"
+        android:textColor="@color/ai_icontext1"
+        android:textDirection="ltr"
+        android:textSize="12sp"
+        tools:text="AUDIO_SCENARIO_AI_CLIENT (10)" />
+
+    <ImageView
+        android:id="@+id/iv_icon"
+        android:layout_width="24dp"
+        android:layout_height="24dp"
+        android:layout_marginStart="8dp"
+        android:background="@drawable/agent_setting_option_check"
+        android:visibility="invisible"
+        tools:visibility="visible" />
+
+</LinearLayout>

--- a/Android/common/src/main/res/layout/common_debug_cov_config_fragment.xml
+++ b/Android/common/src/main/res/layout/common_debug_cov_config_fragment.xml
@@ -1,13 +1,18 @@
 <?xml version="1.0" encoding="utf-8"?>
-<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<androidx.core.widget.NestedScrollView xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:layout_gravity="bottom"
+    android:fillViewport="true"
     tools:background="@color/ai_fill6"
-    android:orientation="vertical"
     tools:theme="@style/Theme.AppCompat">
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
     <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/layout_overall_config"
@@ -40,7 +45,7 @@
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout
-        android:id="@+id/layout_sdk_audio_parameter"
+        android:id="@+id/layout_convoai_request_base_url"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:minHeight="44dp"
@@ -48,6 +53,104 @@
         android:paddingStart="16dp"
         android:paddingEnd="8dp"
         app:layout_constraintTop_toBottomOf="@id/layout_overall_config">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/tv_convoai_request_base_url"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/common_debug_convoai_request_base_url"
+            android:textColor="@color/ai_icontext1"
+            android:textSize="14sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/tv_convoai_request_base_url_desc"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="@string/common_debug_convoai_request_base_url_desc"
+            android:textColor="@color/ai_icontext4"
+            android:textSize="11sp"
+            app:layout_constraintStart_toStartOf="@id/et_convoai_request_base_url"
+            app:layout_constraintTop_toBottomOf="@id/et_convoai_request_base_url" />
+
+        <androidx.appcompat.widget.AppCompatEditText
+            android:id="@+id/et_convoai_request_base_url"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:background="@drawable/edit_text_border_selector"
+            android:hint="https://api-test.agora.io/cn"
+            android:inputType="textUri"
+            android:maxLines="1"
+            android:padding="12dp"
+            android:textColor="@color/ai_fill1"
+            android:textColorHint="@color/ai_brand_black4"
+            android:textSize="12sp"
+            app:layout_constraintTop_toBottomOf="@+id/tv_convoai_request_base_url"
+            tools:text="" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_convoai_request_header"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="44dp"
+        android:orientation="horizontal"
+        android:paddingStart="16dp"
+        android:paddingEnd="8dp"
+        app:layout_constraintTop_toBottomOf="@id/layout_convoai_request_base_url">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/tv_convoai_request_header"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="@string/common_debug_convoai_request_header"
+            android:textColor="@color/ai_icontext1"
+            android:textSize="14sp"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/tv_convoai_request_header_desc"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="6dp"
+            android:text="@string/common_debug_convoai_request_header_desc"
+            android:textColor="@color/ai_icontext4"
+            android:textSize="11sp"
+            app:layout_constraintStart_toStartOf="@id/et_convoai_request_header"
+            app:layout_constraintTop_toBottomOf="@id/et_convoai_request_header" />
+
+        <androidx.appcompat.widget.AppCompatEditText
+            android:id="@+id/et_convoai_request_header"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:background="@drawable/edit_text_border_selector"
+            android:hint="@string/common_debug_convoai_request_header_hint"
+            android:inputType="text"
+            android:maxLines="1"
+            android:padding="12dp"
+            android:textColor="@color/ai_fill1"
+            android:textColorHint="@color/ai_brand_black4"
+            android:textSize="12sp"
+            app:layout_constraintTop_toBottomOf="@+id/tv_convoai_request_header"
+            tools:text="" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_sdk_audio_parameter"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:minHeight="44dp"
+        android:orientation="horizontal"
+        android:paddingStart="16dp"
+        android:paddingEnd="8dp"
+        app:layout_constraintTop_toBottomOf="@id/layout_convoai_request_header">
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/tv_sdk_audio_parameter"
@@ -350,4 +453,5 @@
         android:layout_height="32dp"
         app:layout_constraintBottom_toBottomOf="parent"
         app:layout_constraintTop_toBottomOf="@+id/layout_copy_user_question" />
-</androidx.constraintlayout.widget.ConstraintLayout>
+    </androidx.constraintlayout.widget.ConstraintLayout>
+</androidx.core.widget.NestedScrollView>

--- a/Android/common/src/main/res/layout/common_debug_cov_config_fragment.xml
+++ b/Android/common/src/main/res/layout/common_debug_cov_config_fragment.xml
@@ -182,6 +182,108 @@
     </androidx.constraintlayout.widget.ConstraintLayout>
 
     <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_audio_scenario"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/ai_dp_large"
+        android:orientation="horizontal"
+        android:paddingStart="16dp"
+        android:paddingEnd="8dp"
+        app:layout_constraintTop_toBottomOf="@id/layout_sdk_audio_parameter">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/tv_audio_scenario"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/common_debug_audio_scenario"
+            android:textColor="@color/ai_icontext1"
+            android:textSize="14sp"
+            app:layout_constraintBottom_toTopOf="@+id/tv_audio_scenario_value"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/tv_audio_scenario_value"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="30dp"
+            android:gravity="start"
+            android:text="@string/common_debug_audio_scenario_not_selected"
+            android:textColor="@color/ai_icontext4"
+            android:textSize="12sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_audio_scenario"
+            tools:text="AUDIO_SCENARIO_AI_CLIENT (10)" />
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/icon_dropleft"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="@color/ai_icontext2" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="0.5dp"
+            android:background="@color/ai_line1"
+            app:layout_constraintBottom_toBottomOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
+        android:id="@+id/layout_server_audio_scenario"
+        android:layout_width="match_parent"
+        android:layout_height="@dimen/ai_dp_large"
+        android:orientation="horizontal"
+        android:paddingStart="16dp"
+        android:paddingEnd="8dp"
+        app:layout_constraintTop_toBottomOf="@id/layout_audio_scenario">
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/tv_server_audio_scenario"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/common_debug_server_audio_scenario"
+            android:textColor="@color/ai_icontext1"
+            android:textSize="14sp"
+            app:layout_constraintBottom_toTopOf="@+id/tv_server_audio_scenario_value"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toTopOf="parent" />
+
+        <com.google.android.material.textview.MaterialTextView
+            android:id="@+id/tv_server_audio_scenario_value"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="30dp"
+            android:gravity="start"
+            android:text="@string/common_debug_audio_scenario_not_selected"
+            android:textColor="@color/ai_icontext4"
+            android:textSize="12sp"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@+id/tv_server_audio_scenario"
+            tools:text="aiserver" />
+
+        <ImageView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:src="@drawable/icon_dropleft"
+            app:layout_constraintBottom_toBottomOf="parent"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintTop_toTopOf="parent"
+            app:tint="@color/ai_icontext2" />
+
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="0.5dp"
+            android:background="@color/ai_line1"
+            app:layout_constraintBottom_toBottomOf="parent" />
+    </androidx.constraintlayout.widget.ConstraintLayout>
+
+    <androidx.constraintlayout.widget.ConstraintLayout
         android:id="@+id/layout_api_parameter"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
@@ -189,7 +291,7 @@
         android:orientation="horizontal"
         android:paddingStart="16dp"
         android:paddingEnd="8dp"
-        app:layout_constraintTop_toBottomOf="@id/layout_sdk_audio_parameter">
+        app:layout_constraintTop_toBottomOf="@id/layout_server_audio_scenario">
 
         <com.google.android.material.textview.MaterialTextView
             android:id="@+id/tv_api_parameter"

--- a/Android/common/src/main/res/values/strings.xml
+++ b/Android/common/src/main/res/values/strings.xml
@@ -18,6 +18,9 @@
     <string name="common_debug_switch_tips">Server can be switched before entering the scene.</string>
     <string name="common_debug_convoai_host">ConvoAI Host</string>
     <string name="common_debug_audio_dump">Audio Dump</string>
+    <string name="common_debug_audio_scenario">Client Audio Scenario</string>
+    <string name="common_debug_server_audio_scenario">Server Audio Scenario</string>
+    <string name="common_debug_audio_scenario_not_selected">Not selected</string>
     <string name="common_debug_session_limit">Session Limit</string>
     <string name="common_debug_metrics">Metrics</string>
     <string name="common_debug_graph_id">Graph id</string>

--- a/Android/common/src/main/res/values/strings.xml
+++ b/Android/common/src/main/res/values/strings.xml
@@ -23,6 +23,11 @@
     <string name="common_debug_graph_id">Graph id</string>
     <string name="common_debug_sdk_parameters">SDK audio parameter config</string>
     <string name="common_debug_sc_config">Convo AI service preset config</string>
+    <string name="common_debug_convoai_request_base_url">ConvoAI request domain</string>
+    <string name="common_debug_convoai_request_base_url_desc">(Only overrides the domain portion before the fixed ConvoAI and token API paths)</string>
+    <string name="common_debug_convoai_request_header">X-Service-Namespace</string>
+    <string name="common_debug_convoai_request_header_desc">(Automatically merges with existing remote request headers when provided)</string>
+    <string name="common_debug_convoai_request_header_hint">Enter service namespace</string>
     <string name="common_debug_close">Close Debug Mode</string>
     <string name="common_debug_copy_user_question">Copy current user’s conversation question</string>
     <string name="common_call_time_is_up">Time\'s Up!</string>

--- a/Android/scenes/convoai/src/main/java/io/agora/scene/convoai/api/CovAgentApiManager.kt
+++ b/Android/scenes/convoai/src/main/java/io/agora/scene/convoai/api/CovAgentApiManager.kt
@@ -26,6 +26,38 @@ import org.json.JSONObject
 import java.io.IOException
 import kotlin.math.roundToInt
 
+internal fun createStartRequestConfig(
+    baseUrl: String,
+    namespace: String
+): Map<String, Any>? {
+    val trimmedBaseUrl = baseUrl.trim()
+    val trimmedNamespace = namespace.trim()
+    if (trimmedBaseUrl.isEmpty() && trimmedNamespace.isEmpty()) {
+        return null
+    }
+
+    val convoaiConfig = mutableMapOf<String, Any>()
+    if (trimmedBaseUrl.isNotEmpty()) {
+        convoaiConfig["base_url"] = trimmedBaseUrl
+    }
+    if (trimmedNamespace.isNotEmpty()) {
+        convoaiConfig["headers"] = mapOf("X-Service-Namespace" to trimmedNamespace)
+    }
+
+    return mapOf("convoai" to convoaiConfig)
+}
+
+internal fun buildDebugStartRequestConfig(
+    isDebug: Boolean,
+    baseUrl: String,
+    namespace: String
+): Map<String, Any>? {
+    if (!isDebug) {
+        return null
+    }
+    return createStartRequestConfig(baseUrl, namespace)
+}
+
 object CovAgentApiManager {
 
     private const val TAG = "CovServerManager"
@@ -61,23 +93,7 @@ object CovAgentApiManager {
     internal fun buildStartRequestConfig(
         baseUrl: String,
         namespace: String
-    ): Map<String, Any>? {
-        val trimmedBaseUrl = baseUrl.trim()
-        val trimmedNamespace = namespace.trim()
-        if (trimmedBaseUrl.isEmpty() && trimmedNamespace.isEmpty()) {
-            return null
-        }
-
-        val convoaiConfig = mutableMapOf<String, Any>()
-        if (trimmedBaseUrl.isNotEmpty()) {
-            convoaiConfig["base_url"] = trimmedBaseUrl
-        }
-        if (trimmedNamespace.isNotEmpty()) {
-            convoaiConfig["headers"] = mapOf("X-Service-Namespace" to trimmedNamespace)
-        }
-
-        return mapOf("convoai" to convoaiConfig)
-    }
+    ): Map<String, Any>? = createStartRequestConfig(baseUrl, namespace)
 
     fun startAgentWithMap(channelName:String,convoaiBody: Map<String,Any?>, completion: (error: ApiException?, channelName: String) -> Unit) {
         val requestURL = "${ServerConfig.toolBoxUrl}/convoai/$SERVICE_VERSION/start"
@@ -111,9 +127,10 @@ object CovAgentApiManager {
             // Process convoaiBody, convert Map to JSONObject and filter out null values
             val convoaiJsonObject = mapToJsonObjectWithFilter(convoaiBody)
             postBody.put("convoai_body", convoaiJsonObject)
-            buildStartRequestConfig(
-                DebugConfigSettings.convoAiRequestBaseUrl,
-                DebugConfigSettings.convoAiRequestHeaderNamespace
+            buildDebugStartRequestConfig(
+                isDebug = DebugConfigSettings.isDebug,
+                baseUrl = DebugConfigSettings.convoAiRequestBaseUrl,
+                namespace = DebugConfigSettings.convoAiRequestHeaderNamespace
             )?.let { requestConfig ->
                 postBody.put("request_config", mapToJsonObjectWithFilter(requestConfig))
             }

--- a/Android/scenes/convoai/src/main/java/io/agora/scene/convoai/api/CovAgentApiManager.kt
+++ b/Android/scenes/convoai/src/main/java/io/agora/scene/convoai/api/CovAgentApiManager.kt
@@ -4,6 +4,7 @@ import com.google.gson.JsonObject
 import io.agora.scene.common.BuildConfig
 import io.agora.scene.common.constant.SSOUserManager
 import io.agora.scene.common.constant.ServerConfig
+import io.agora.scene.common.debugMode.DebugConfigSettings
 import io.agora.scene.common.net.SecureOkHttpClient
 import io.agora.scene.common.util.GsonTools
 import io.agora.scene.common.util.TimeUtils
@@ -57,6 +58,27 @@ object CovAgentApiManager {
         val uploadedAtMs: Long
     )
 
+    internal fun buildStartRequestConfig(
+        baseUrl: String,
+        namespace: String
+    ): Map<String, Any>? {
+        val trimmedBaseUrl = baseUrl.trim()
+        val trimmedNamespace = namespace.trim()
+        if (trimmedBaseUrl.isEmpty() && trimmedNamespace.isEmpty()) {
+            return null
+        }
+
+        val convoaiConfig = mutableMapOf<String, Any>()
+        if (trimmedBaseUrl.isNotEmpty()) {
+            convoaiConfig["base_url"] = trimmedBaseUrl
+        }
+        if (trimmedNamespace.isNotEmpty()) {
+            convoaiConfig["headers"] = mapOf("X-Service-Namespace" to trimmedNamespace)
+        }
+
+        return mapOf("convoai" to convoaiConfig)
+    }
+
     fun startAgentWithMap(channelName:String,convoaiBody: Map<String,Any?>, completion: (error: ApiException?, channelName: String) -> Unit) {
         val requestURL = "${ServerConfig.toolBoxUrl}/convoai/$SERVICE_VERSION/start"
         val postBody = JSONObject()
@@ -89,6 +111,12 @@ object CovAgentApiManager {
             // Process convoaiBody, convert Map to JSONObject and filter out null values
             val convoaiJsonObject = mapToJsonObjectWithFilter(convoaiBody)
             postBody.put("convoai_body", convoaiJsonObject)
+            buildStartRequestConfig(
+                DebugConfigSettings.convoAiRequestBaseUrl,
+                DebugConfigSettings.convoAiRequestHeaderNamespace
+            )?.let { requestConfig ->
+                postBody.put("request_config", mapToJsonObjectWithFilter(requestConfig))
+            }
 
         } catch (e: JSONException) {
             CovLogger.e(TAG, "postBody error ${e.message}")

--- a/Android/scenes/convoai/src/main/java/io/agora/scene/convoai/ui/living/CovLivingViewModel.kt
+++ b/Android/scenes/convoai/src/main/java/io/agora/scene/convoai/ui/living/CovLivingViewModel.kt
@@ -14,6 +14,7 @@ import io.agora.scene.common.net.ApiManager
 import io.agora.scene.common.net.TokenGenerator
 import io.agora.scene.common.net.TokenGeneratorType
 import io.agora.scene.common.net.UploadImage
+import io.agora.scene.common.debugMode.DebugConfigSettings
 import io.agora.scene.common.util.TimeUtils
 import io.agora.scene.common.util.toast.ToastUtil
 import io.agora.scene.convoai.CovLogger
@@ -368,7 +369,7 @@ class CovLivingViewModel : ViewModel() {
 
                 // Configure audio settings
                 val isIndependent = CovAgentManager.getPreset()?.isIndependent == true
-                val scenario = if (CovAgentManager.isEnableAvatar) {
+                val defaultScenario = if (CovAgentManager.isEnableAvatar) {
                     // If digital avatar is enabled, use AUDIO_SCENARIO_DEFAULT for better audio mixing
                     Constants.AUDIO_SCENARIO_DEFAULT
                 } else {
@@ -378,6 +379,7 @@ class CovLivingViewModel : ViewModel() {
                         Constants.AUDIO_SCENARIO_AI_CLIENT
                     }
                 }
+                val scenario = DebugConfigSettings.audioScenario ?: defaultScenario
                 conversationalAIAPI?.loadAudioSettings(scenario)
 
                 // Join RTC channel
@@ -1048,6 +1050,7 @@ class CovLivingViewModel : ViewModel() {
                     "data_channel" to "rtm",
                     "enable_metrics" to CovAgentManager.isMetricsEnabled,
                     "enable_error_message" to true,
+                    "audio_scenario" to DebugConfigSettings.serverAudioScenario,
                     "transcript" to mapOf(
                         "enable" to true,
                         "enable_words" to CovAgentManager.isWordRenderMode,
@@ -1216,6 +1219,7 @@ class CovLivingViewModel : ViewModel() {
                 "data_channel" to "rtm",
                 "enable_metrics" to true,
                 "enable_error_message" to true,
+                "audio_scenario" to DebugConfigSettings.serverAudioScenario,
                 "transcript" to mutableMapOf<String, Any?>(
                     "enable" to true,
                     "enable_words" to CovAgentManager.isWordRenderMode,

--- a/Android/scenes/convoai/src/main/java/io/agora/scene/convoai/ui/living/CovLivingViewModel.kt
+++ b/Android/scenes/convoai/src/main/java/io/agora/scene/convoai/ui/living/CovLivingViewModel.kt
@@ -77,6 +77,28 @@ import kotlin.coroutines.suspendCoroutine
 /**
  * view model
  */
+internal fun resolveAudioScenario(
+    defaultScenario: Int,
+    isDebug: Boolean,
+    debugAudioScenario: Int?
+): Int {
+    return if (isDebug) {
+        debugAudioScenario ?: defaultScenario
+    } else {
+        defaultScenario
+    }
+}
+
+internal fun resolveDebugServerAudioScenario(
+    isDebug: Boolean,
+    serverAudioScenario: String?
+): String? {
+    if (!isDebug) {
+        return null
+    }
+    return serverAudioScenario
+}
+
 class CovLivingViewModel : ViewModel() {
 
     private val TAG = "CovLivingViewModel"
@@ -379,7 +401,11 @@ class CovLivingViewModel : ViewModel() {
                         Constants.AUDIO_SCENARIO_AI_CLIENT
                     }
                 }
-                val scenario = DebugConfigSettings.audioScenario ?: defaultScenario
+                val scenario = resolveAudioScenario(
+                    defaultScenario = defaultScenario,
+                    isDebug = DebugConfigSettings.isDebug,
+                    debugAudioScenario = DebugConfigSettings.audioScenario
+                )
                 conversationalAIAPI?.loadAudioSettings(scenario)
 
                 // Join RTC channel
@@ -1050,7 +1076,10 @@ class CovLivingViewModel : ViewModel() {
                     "data_channel" to "rtm",
                     "enable_metrics" to CovAgentManager.isMetricsEnabled,
                     "enable_error_message" to true,
-                    "audio_scenario" to DebugConfigSettings.serverAudioScenario,
+                    "audio_scenario" to resolveDebugServerAudioScenario(
+                        isDebug = DebugConfigSettings.isDebug,
+                        serverAudioScenario = DebugConfigSettings.serverAudioScenario
+                    ),
                     "transcript" to mapOf(
                         "enable" to true,
                         "enable_words" to CovAgentManager.isWordRenderMode,
@@ -1219,7 +1248,10 @@ class CovLivingViewModel : ViewModel() {
                 "data_channel" to "rtm",
                 "enable_metrics" to true,
                 "enable_error_message" to true,
-                "audio_scenario" to DebugConfigSettings.serverAudioScenario,
+                "audio_scenario" to resolveDebugServerAudioScenario(
+                    isDebug = DebugConfigSettings.isDebug,
+                    serverAudioScenario = DebugConfigSettings.serverAudioScenario
+                ),
                 "transcript" to mutableMapOf<String, Any?>(
                     "enable" to true,
                     "enable_words" to CovAgentManager.isWordRenderMode,

--- a/Android/scenes/convoai/src/test/java/io/agora/scene/convoai/api/CovAgentApiManagerDebugConfigTest.kt
+++ b/Android/scenes/convoai/src/test/java/io/agora/scene/convoai/api/CovAgentApiManagerDebugConfigTest.kt
@@ -1,0 +1,48 @@
+package io.agora.scene.convoai.api
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CovAgentApiManagerDebugConfigTest {
+
+    @Test
+    fun buildDebugStartRequestConfig_ignoresDebugConfigWhenDebugIsDisabled() {
+        val config = buildDebugStartRequestConfig(
+            isDebug = false,
+            baseUrl = "https://example.com",
+            namespace = "debug-namespace"
+        )
+
+        assertNull(config)
+    }
+
+    @Test
+    fun buildDebugStartRequestConfig_returnsNullWhenDebugConfigIsEmpty() {
+        val config = buildDebugStartRequestConfig(
+            isDebug = true,
+            baseUrl = " ",
+            namespace = " "
+        )
+
+        assertNull(config)
+    }
+
+    @Test
+    fun buildDebugStartRequestConfig_usesDebugConfigWhenDebugIsEnabled() {
+        val config = buildDebugStartRequestConfig(
+            isDebug = true,
+            baseUrl = " https://example.com ",
+            namespace = " debug-namespace "
+        )
+
+        val convoai = config?.get("convoai") as? Map<*, *>
+        assertNotNull(convoai)
+        assertEquals("https://example.com", convoai?.get("base_url"))
+        assertEquals(
+            mapOf("X-Service-Namespace" to "debug-namespace"),
+            convoai?.get("headers")
+        )
+    }
+}

--- a/Android/scenes/convoai/src/test/java/io/agora/scene/convoai/ui/living/CovLivingDebugOverrideTest.kt
+++ b/Android/scenes/convoai/src/test/java/io/agora/scene/convoai/ui/living/CovLivingDebugOverrideTest.kt
@@ -1,0 +1,61 @@
+package io.agora.scene.convoai.ui.living
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class CovLivingDebugOverrideTest {
+
+    @Test
+    fun resolveAudioScenario_ignoresDebugOverrideWhenDebugIsDisabled() {
+        val scenario = resolveAudioScenario(
+            defaultScenario = 10,
+            isDebug = false,
+            debugAudioScenario = 3
+        )
+
+        assertEquals(10, scenario)
+    }
+
+    @Test
+    fun resolveAudioScenario_usesDebugOverrideWhenDebugIsEnabled() {
+        val scenario = resolveAudioScenario(
+            defaultScenario = 10,
+            isDebug = true,
+            debugAudioScenario = 3
+        )
+
+        assertEquals(3, scenario)
+    }
+
+    @Test
+    fun resolveAudioScenario_usesDefaultWhenDebugOverrideIsMissing() {
+        val scenario = resolveAudioScenario(
+            defaultScenario = 10,
+            isDebug = true,
+            debugAudioScenario = null
+        )
+
+        assertEquals(10, scenario)
+    }
+
+    @Test
+    fun resolveDebugServerAudioScenario_ignoresDebugOverrideWhenDebugIsDisabled() {
+        val scenario = resolveDebugServerAudioScenario(
+            isDebug = false,
+            serverAudioScenario = "aiserver"
+        )
+
+        assertNull(scenario)
+    }
+
+    @Test
+    fun resolveDebugServerAudioScenario_usesDebugOverrideWhenDebugIsEnabled() {
+        val scenario = resolveDebugServerAudioScenario(
+            isDebug = true,
+            serverAudioScenario = "aiserver"
+        )
+
+        assertEquals("aiserver", scenario)
+    }
+}

--- a/cicd/build_scripts/build_ios.groovy
+++ b/cicd/build_scripts/build_ios.groovy
@@ -51,6 +51,10 @@ def doPublish(buildVariables) {
     archiveUrls = archiveUrls as Set
     if (archiveUrls) {
         def content = archiveUrls.join("\n")
+        echo "===================================================="
+        echo "Artifact uploaded successfully! Download URL:"
+        echo content
+        echo "===================================================="
         writeFile(file: 'package_urls', text: content, encoding: "utf-8")
     }
     archiveArtifacts(artifacts: "package_urls", allowEmptyArchive:true)

--- a/cicd/build_scripts/build_ios.sh
+++ b/cicd/build_scripts/build_ios.sh
@@ -18,7 +18,6 @@ if [ -z "$build_time" ]; then
     export build_time=$(date +%H%M%S)
 fi
 
-BUILD_VERSION=$(date +%Y%m%d%H%M%S)
 CURRENT_PATH=$PWD
 # Project target name
 PROJECT_NAME=Agent
@@ -172,6 +171,16 @@ if [ -z "$release_version" ]; then
 fi
 echo "Version number read from project configuration: ${release_version}"
 
+export BUILD_VERSION=$(xcodebuild -workspace "${PROJECT_PATH}/${PROJECT_NAME}.xcworkspace" -scheme "${TARGET_NAME}" -showBuildSettings | grep "CURRENT_PROJECT_VERSION" | head -n 1 | cut -d "=" -f 2 | tr -d " ")
+if [ -z "$BUILD_VERSION" ]; then
+    echo "Error: Unable to read build number from project configuration"
+    exit 1
+fi
+echo "Build number read from project configuration: ${BUILD_VERSION}"
+
+export ARTIFACT_TIMESTAMP=$(date +%Y%m%d%H%M%S)
+echo "Artifact timestamp: ${ARTIFACT_TIMESTAMP}"
+
 KEYCENTER_PATH=${PROJECT_PATH}"/"${PROJECT_NAME}"/KeyCenter.swift"
 
 # Build environment
@@ -193,7 +202,7 @@ else
 fi
 
 # Artifact name
-export ARTIFACT_NAME="Agora_AI_Scenarios_Demo_for_iOS_${PROVISIONING_PROFILE}_v${release_version}_${BUILD_VERSION}"
+export ARTIFACT_NAME="Agora_AI_Scenarios_Demo_for_iOS_${PROVISIONING_PROFILE}_v${release_version}_${BUILD_VERSION}_${ARTIFACT_TIMESTAMP}"
 # Project file path
 APP_PATH="${PROJECT_PATH}/${PROJECT_NAME}.xcworkspace"
 
@@ -219,16 +228,12 @@ fi
 
 security unlock-keychain -p "123456" ~/Library/Keychains/login.keychain
 # Main project configuration
-# Debug
-sed -i '' "s|CURRENT_PROJECT_VERSION = .*;|CURRENT_PROJECT_VERSION = ${BUILD_VERSION};|g" $PBXPROJ_PATH
 sed -i '' "s|PRODUCT_BUNDLE_IDENTIFIER = .*;|PRODUCT_BUNDLE_IDENTIFIER = \"${bundle_id}\";|g" $PBXPROJ_PATH
 sed -i '' "s|CODE_SIGN_STYLE = .*;|CODE_SIGN_STYLE = \"Manual\";|g" $PBXPROJ_PATH
 sed -i '' "s|DEVELOPMENT_TEAM = .*;|DEVELOPMENT_TEAM = \"${DEVELOPMENT_TEAM}\";|g" $PBXPROJ_PATH
 sed -i '' "s|PROVISIONING_PROFILE_SPECIFIER = .*;|PROVISIONING_PROFILE_SPECIFIER = \"${PROVISIONING_PROFILE}\";|g" $PBXPROJ_PATH
 sed -i '' "s|CODE_SIGN_IDENTITY = .*;|CODE_SIGN_IDENTITY = \"${CODE_SIGN_IDENTITY}\";|g" $PBXPROJ_PATH
 
-# Release
-sed -i '' "s|CURRENT_PROJECT_VERSION = .*;|CURRENT_PROJECT_VERSION = ${BUILD_VERSION};|g" $PBXPROJ_PATH
 sed -i '' "s|PRODUCT_BUNDLE_IDENTIFIER = .*;|PRODUCT_BUNDLE_IDENTIFIER = \"${bundle_id}\";|g" $PBXPROJ_PATH
 sed -i '' "s|CODE_SIGN_STYLE = .*;|CODE_SIGN_STYLE = \"Manual\";|g" $PBXPROJ_PATH
 sed -i '' "s|DEVELOPMENT_TEAM = .*;|DEVELOPMENT_TEAM = \"${DEVELOPMENT_TEAM}\";|g" $PBXPROJ_PATH
@@ -345,28 +350,7 @@ cd "${PACKAGE_DIR}"
 zip -r "${WORKSPACE}/${ARTIFACT_NAME}.zip" ./
 cd "${WORKSPACE}"
 
-# Upload file and delete local zip for non-local builds
-if [ "$LOCALPACKAGE" != "true" ]; then
-    echo "Uploading artifact to artifact repository..."
-    
-    # Upload file to artifact repository and save output
-    UPLOAD_RESULT=$(python3 artifactory_utils.py --action=upload_file --file="${ARTIFACT_NAME}.zip" --project)
-    
-    # Check if upload result is a URL
-    if [[ "$UPLOAD_RESULT" =~ ^https?:// ]]; then
-        echo "====🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉🎉========="
-        echo "Artifact uploaded successfully! Download URL:"
-        echo "$UPLOAD_RESULT"
-        echo "===================================================="
-    else
-        echo "Warning: Upload result format is abnormal"
-        echo "Complete upload result:"
-        echo "$UPLOAD_RESULT"
-    fi
-    
-    # Clean up local artifact
-    rm -f "${ARTIFACT_NAME}.zip"
-fi
+# Artifact upload is handled by the Jenkins publish stage.
 
 # Clean up files
 rm -rf ${TARGET_NAME}_${BUILD_VERSION}.xcarchive


### PR DESCRIPTION
## Summary
- Add ConvoAI debug controls for request domain, service namespace, client audio scenario, and server audio scenario.
- Apply selected client audio scenario only when explicitly chosen, preserving the default runtime scenario logic otherwise.
- Pass server `audio_scenario` and optional `request_config` only through debug settings.
- Align iOS CI packaging to read `CURRENT_PROJECT_VERSION` from the Xcode project, use a timestamp only for zip artifact uniqueness, and let Jenkins publish handle artifact upload.